### PR TITLE
Trying to improve the structure and making my changes to the rule engine clearer

### DIFF
--- a/src/main/resources/config/config.properties
+++ b/src/main/resources/config/config.properties
@@ -1,5 +1,5 @@
 # Rules-production
-rulePaths=rules/deployment/credibility_mapping/misinfome.json;rules/deployment/credibility_mapping/accumelate.json
+rulePaths=rules/deployment/credibility_mapping/misinfome.json;rules/deployment/credibility_mapping/aggregate.json
 
 # Threshold of each modules
 threshold_similarity= 0.5

--- a/src/main/resources/rules/deployment/credibility_mapping/aggregate.json
+++ b/src/main/resources/rules/deployment/credibility_mapping/aggregate.json
@@ -1,11 +1,11 @@
 [
   {
-    "name": "accumelate_module_evaluations",
+    "name": "aggregate_module_evaluations",
     "description": "Takes the results from the module responses and set a final credibility",
     "priority": 10,
     "condition": "true",
     "actions": [
-      "it = callback.getModuleCredibility().values().iterator(); if(it.hasNext()) { callback.setFinalCredibility(it.next()); }"
+      "callback.setFinalCredibility(callback.averageCredibility(callback.getModuleCredibility().values()));"
     ]
   }
 ]


### PR DESCRIPTION
Renamed accumelate.json to aggregate.json in trying to make its function more clear.

Made the aggregate use a rule that simply returns an "average" of the labels as a more functioning naive and simple strategy to summarize the module's labels.

The callback used class looks as follows:

package eu.coinform.gateway.rule_engine;

import lombok.Getter;
import lombok.Setter;
import model.Credibility;
import rule.engine.Callback;

import java.util.Collection;
import java.util.HashMap;
import java.util.Map;

public class PolicyEngineCallback implements Callback {

    @Getter
    private Map<String, Credibility> moduleCredibility;
    @Setter
    @Getter
    private Credibility finalCredibility;

    public PolicyEngineCallback() {
        moduleCredibility = new HashMap<>();
        this.finalCredibility = Credibility.not_verifiable_post;
    }

    public Credibility averageCredibility(Collection<Credibility> credibilityLabels) {
        int cred_sum = 0;
        int cred_count = 0;
        for (Credibility cred : credibilityLabels) {
            cred_sum += cred.ordinal();
            cred_count++;
        }
        return Credibility.values()[cred_sum/cred_count];
    }
}
